### PR TITLE
Refatoração: Implementação do Mapper e DTO para Missoes

### DIFF
--- a/src/main/java/dev/java10x/cadastrodeninjas/Missoes/controller/MissoesController.java
+++ b/src/main/java/dev/java10x/cadastrodeninjas/Missoes/controller/MissoesController.java
@@ -1,5 +1,6 @@
 package dev.java10x.cadastrodeninjas.Missoes.controller;
 
+import dev.java10x.cadastrodeninjas.Missoes.dto.MissoesDTO;
 import dev.java10x.cadastrodeninjas.Missoes.model.MissoesModel;
 import dev.java10x.cadastrodeninjas.Missoes.service.MissoesService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,25 +21,25 @@ public class MissoesController {
 
     //GET -- Mandar uma requisicao para mostrar as missoes
     @GetMapping("/listar")
-    public List<MissoesModel> listarMissoes(){
+    public List<MissoesDTO> listarMissoes(){
         return missoesService.listarMissoes();
     }
 
     //GET -- Mandar uma requisicao para mostrar missao por id
     @GetMapping("/listar/{id}")
-    public MissoesModel listarMissaoPorId(@PathVariable Long id){
+    public MissoesDTO listarMissaoPorId(@PathVariable Long id){
         return missoesService.listarMissaoPorId(id);
     }
 
     //POST -- Mandar uma requisicao para criar as missoes
     @PostMapping("/criar")
-    public MissoesModel criarMissao(@RequestBody MissoesModel missoesModel){
-        return missoesService.criarMissao(missoesModel);
+    public MissoesDTO criarMissao(@RequestBody MissoesDTO missao){
+        return missoesService.criarMissao(missao);
     }
 
     //PUT -- Mandar uma requisicao para alterar as missoes
     @PutMapping("/alterar/{id}")
-    public MissoesModel alterarMissao(@PathVariable Long id, @RequestBody MissoesModel missoesAtualizado){
+    public MissoesDTO alterarMissao(@PathVariable Long id, @RequestBody MissoesDTO missoesAtualizado){
         return missoesService.atualizarMissao(id, missoesAtualizado);
     }
 

--- a/src/main/java/dev/java10x/cadastrodeninjas/Missoes/dto/MissoesDTO.java
+++ b/src/main/java/dev/java10x/cadastrodeninjas/Missoes/dto/MissoesDTO.java
@@ -1,0 +1,4 @@
+package dev.java10x.cadastrodeninjas.Missoes.dto;
+
+public class MissoesDTO {
+}

--- a/src/main/java/dev/java10x/cadastrodeninjas/Missoes/dto/MissoesDTO.java
+++ b/src/main/java/dev/java10x/cadastrodeninjas/Missoes/dto/MissoesDTO.java
@@ -1,4 +1,17 @@
 package dev.java10x.cadastrodeninjas.Missoes.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class MissoesDTO {
+
+    private Long id;
+    private String nome;
+    private String dificuldade;
+
+
 }

--- a/src/main/java/dev/java10x/cadastrodeninjas/Missoes/mapper/MissoesMapper.java
+++ b/src/main/java/dev/java10x/cadastrodeninjas/Missoes/mapper/MissoesMapper.java
@@ -10,7 +10,7 @@ public class MissoesMapper {
         MissoesModel missoesModel = new MissoesModel();
         missoesModel.setId(missoesDTO.getId());
         missoesModel.setNome(missoesDTO.getNome());
-        missoesModel.setNome(missoesDTO.getDificuldade());
+        missoesModel.setDificuldade(missoesDTO.getDificuldade());
 
         return missoesModel;
     }

--- a/src/main/java/dev/java10x/cadastrodeninjas/Missoes/mapper/MissoesMapper.java
+++ b/src/main/java/dev/java10x/cadastrodeninjas/Missoes/mapper/MissoesMapper.java
@@ -1,4 +1,27 @@
 package dev.java10x.cadastrodeninjas.Missoes.mapper;
 
+import dev.java10x.cadastrodeninjas.Missoes.dto.MissoesDTO;
+import dev.java10x.cadastrodeninjas.Missoes.model.MissoesModel;
+import org.springframework.stereotype.Component;
+
+@Component
 public class MissoesMapper {
+    public MissoesModel map(MissoesDTO missoesDTO) {
+        MissoesModel missoesModel = new MissoesModel();
+        missoesModel.setId(missoesDTO.getId());
+        missoesModel.setNome(missoesDTO.getNome());
+        missoesModel.setNome(missoesDTO.getDificuldade());
+
+        return missoesModel;
+    }
+
+    public MissoesDTO map(MissoesModel missoesModel) {
+        MissoesDTO missoesDTO = new MissoesDTO();
+        missoesDTO.setId(missoesModel.getId());
+        missoesDTO.setNome(missoesModel.getNome());
+        missoesDTO.setDificuldade(missoesModel.getDificuldade());
+
+        return missoesDTO;
+    }
+
 }

--- a/src/main/java/dev/java10x/cadastrodeninjas/Missoes/mapper/MissoesMapper.java
+++ b/src/main/java/dev/java10x/cadastrodeninjas/Missoes/mapper/MissoesMapper.java
@@ -1,0 +1,4 @@
+package dev.java10x.cadastrodeninjas.Missoes.mapper;
+
+public class MissoesMapper {
+}

--- a/src/main/java/dev/java10x/cadastrodeninjas/Missoes/service/MissoesService.java
+++ b/src/main/java/dev/java10x/cadastrodeninjas/Missoes/service/MissoesService.java
@@ -1,37 +1,51 @@
 package dev.java10x.cadastrodeninjas.Missoes.service;
 
+import dev.java10x.cadastrodeninjas.Missoes.dto.MissoesDTO;
+import dev.java10x.cadastrodeninjas.Missoes.mapper.MissoesMapper;
 import dev.java10x.cadastrodeninjas.Missoes.model.MissoesModel;
 import dev.java10x.cadastrodeninjas.Missoes.repository.MissoesRepository;
 import dev.java10x.cadastrodeninjas.Ninjas.model.NinjaModel;
+import dev.java10x.cadastrodeninjas.Ninjas.repository.NinjaRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 
 @Service
 public class MissoesService {
 
+    private final NinjaRepository ninjaRepository;
     private MissoesRepository missoesRepository;
+    private MissoesMapper missoesMapper;
 
-    public MissoesService(MissoesRepository missoesRepository) {
+
+    public MissoesService(MissoesRepository missoesRepository, MissoesMapper missoesMapper, NinjaRepository ninjaRepository) {
         this.missoesRepository = missoesRepository;
+        this.missoesMapper = missoesMapper;
+        this.ninjaRepository = ninjaRepository;
     }
 
-    //Listar todas as missoes
-    public List<MissoesModel> listarMissoes(){
-        return missoesRepository.findAll();
+    public List<MissoesDTO> listarMissoes(){
+        List<MissoesModel> missoes = missoesRepository.findAll();
+        return missoes.stream()
+                .map(missoesMapper::map)
+                .collect(Collectors.toList());
     }
 
     //Listar missoes por ID
-    public MissoesModel listarMissaoPorId(Long id){
+    public MissoesDTO listarMissaoPorId(Long id){
         Optional<MissoesModel> missoePorId = missoesRepository.findById(id);
-        return missoePorId.orElse(null);
+        return missoePorId.map(missoesMapper::map).orElse(null);
     }
 
     //Criar uma nova missao
-    public MissoesModel criarMissao(MissoesModel missoesModel){
-        return missoesRepository.save(missoesModel);
+    public MissoesDTO criarMissao(MissoesDTO missoesDTO){
+        MissoesModel missoes = missoesMapper.map(missoesDTO);
+        missoes =  missoesRepository.save(missoes);
+        return missoesMapper.map(missoes);
     }
 
     //Deletar uma missao
@@ -40,10 +54,13 @@ public class MissoesService {
     }
 
     //Atualizar uma missao
-    public MissoesModel atualizarMissao(Long id, MissoesModel missoesAtualizado){
-        if(missoesRepository.existsById(id)){
-            missoesAtualizado.setId(id);
-            return missoesRepository.save(missoesAtualizado);
+    public MissoesDTO atualizarMissao(Long id, MissoesDTO MissoesDTO){
+        Optional<MissoesModel> missaoExistente = missoesRepository.findById(id);
+        if(missaoExistente.isPresent()){
+            MissoesModel missaoAtualizada = missoesMapper.map(MissoesDTO);
+            missaoAtualizada.setId(id);
+            MissoesModel missaoSalva = missoesRepository.save(missaoAtualizada);
+            return missoesMapper.map(missaoSalva);
         }
         return null;
     }


### PR DESCRIPTION
Alterações propostas pelo PR

- Implementação do MissoesMapper para conversão entre MissoesModel e MissoesDTO.
- Criação do MissoesDTO contendo os campos necessários para comunicação externa.
- Refatoração do MissoesService para utilizar o MissoesDTO, eliminando a exposição direta do MissoesModel.
- Ajustes no MissoesController para trabalhar com o MissoesDTO, garantindo uma estrutura mais coesa e desacoplada.

Essas mudanças visam melhorar a organização do código e a separação de responsabilidades, facilitando a manutenção e expansão futura da aplicação.